### PR TITLE
Potential fix for code scanning alert no. 18: Shell command built from environment values

### DIFF
--- a/renderer/render_frame.js
+++ b/renderer/render_frame.js
@@ -895,12 +895,21 @@ module.exports = {
                                 response = await execFilePromise(upload_script, [`${file_path}/video.${options.type}`]);
                                 const url = new URL(response.stdout);
                             } else {
-                                const upload_command = config.upload_command.replace('{path}', `${file_path}/video.${options.type}`);
+                                const uploadPath = `${file_path}/video.${options.type}`;
+                                const commandParts = (config.upload_command.match(/(?:[^\s"]+|"[^"]*")+/g) || [])
+                                    .map(part => part.replace(/^"|"$/g, ''))
+                                    .map(part => part.replace('{path}', uploadPath));
+
+                                if (commandParts.length === 0)
+                                    throw new Error('Invalid upload_command: empty command');
+
+                                const uploadCommand = commandParts[0];
+                                const uploadArgs = commandParts.slice(1);
 
                                 if (helper.debug)
                                     console.log('running upload command: ', config.upload_command);
 
-                                response = await execPromise(upload_command);
+                                response = await execFilePromise(uploadCommand, uploadArgs);
                             }
                             
                             const url = new URL(response.stdout);


### PR DESCRIPTION
Potential fix for [https://github.com/ParaliyzedEvo/flowabot/security/code-scanning/18](https://github.com/ParaliyzedEvo/flowabot/security/code-scanning/18)

Best fix: stop using `exec` with a dynamically interpolated command string. Instead, parse `config.upload_command` into a program plus argument array, replace `{path}` in each token, and execute with `execFile` so arguments are passed directly without shell parsing.

In `renderer/render_frame.js`, edit the upload fallback block around lines 898–903:
- Replace `upload_command` string construction + `execPromise(upload_command)` with:
  - tokenization of `config.upload_command` into argv-like parts (supports quoted segments),
  - `{path}` replacement per token,
  - `command = parts[0]`, `args = parts.slice(1)`,
  - `execFilePromise(command, args)`.
- Keep existing behavior otherwise (same stdout handling, debug logging, URL parsing).
- No new dependency is required; implement a small local tokenizer in-place.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
